### PR TITLE
Add Output format column to table

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -20,12 +20,12 @@ knitr::opts_chunk$set(
 
 ## Available Hooks
 
-The below table details the hooks currently available within the package.
+The below table details the hooks currently available within the package. Some hooks are only available for particular output formats.
 
-| hook name           | description                                 |
-|---------------------|---------------------------------------------|
-| `output_lines`      | Print user specified lines of R output      |
-| `output_max_height` | Add a scrollbar to output of a given height |
+| hook name           | description                                 | HTML   | PDF   |
+|---------------------|---------------------------------------------|--------|-------|
+| `output_lines`      | Print user specified lines of R output      | X      | X     | 
+| `output_max_height` | Add a scrollbar to output of a given height | X      |       |
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Available Hooks
 
 The below table details the hooks currently available within the package.
 
-| hook name           | description                                 |
-|---------------------|---------------------------------------------|
-| `output_lines`      | Print user specified lines of R output      |
-| `output_max_height` | Add a scrollbar to output of a given height |
+| hook name           | description                                 | HTML | PDF |
+|---------------------|---------------------------------------------|------|-----|
+| `output_lines`      | Print user specified lines of R output      | X    | X   |
+| `output_max_height` | Add a scrollbar to output of a given height | X    |     |
 
 Usage
 -----


### PR DESCRIPTION
I think it is useful showing on the table which hooks can be used for each output format. Ideally, we can make as many as possible work across both formats!

We could add a Word column, but I tend to ignore this format :P